### PR TITLE
MultiFileGtool3のバグ修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # xgtool3
+
 A Python library to read Gtool3 files as an xarray DataArray.
 
 ## Installation
+
 ```sh
 pip install git+https://github.com/k1bb/xgtool3
 ```
@@ -14,6 +16,7 @@ pip install git+https://github.com/k1bb/xgtool3
 ## How to use
 
 ### Open a single file
+
 ```python
 import xgtool3 as xgt3
 path = 'your_data_dir/ATM/Ts'
@@ -22,10 +25,11 @@ da = file.open()
 ```
 
 ### Open multiple files separated by year
+
 ```python
-import xgtool3
+import xgtool3 as xgt3
 path = 'your_data_dir/y????/OCN/sst'
 # You can specify the path using wildcards.
-files = xgt3.Gtool3(path)
-da = gt3.open()
+files = xgt3.MultiFileGtool3(path)
+da = files.mfopen()
 ```

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,10 @@
 
 from setuptools import setup, find_packages
 
-setup(name='xgtool3', 
-      version='2.1.0', 
-      author='Keiichi Hashimoto', 
-      author_email='k1bridgebook@g.ecc.u-tokyo.ac.jp', 
-      packages=find_packages()
+setup(
+    name="xgtool3",
+    version="2.1.1",
+    author="Keiichi Hashimoto",
+    author_email="k1bridgebook@g.ecc.u-tokyo.ac.jp",
+    packages=find_packages(),
 )

--- a/xgtool3/xgtool3.py
+++ b/xgtool3/xgtool3.py
@@ -71,7 +71,7 @@ class MultiFileGtool3:
         return path
 
     def mfopen(self, unstack=True):
-        files = [Gtool3(path, self.datainfo) for path in self.paths]
+        files = [Gtool3(path) for path in self.paths]
         data = [file.open_data() for file in files]
         data = da.concatenate(data)
         time = [file.make_time_ax() for file in files]

--- a/xgtool3/xgtool3.py
+++ b/xgtool3/xgtool3.py
@@ -2,6 +2,7 @@
 
 import os
 import glob
+import sys
 from datetime import datetime
 import cftime
 import numpy as np
@@ -385,12 +386,11 @@ class Gtool3Ax(Gtool3):
             title = DIMNAME[self.datainfo["title"]]
         else:
             title = self.datainfo["title"]
-        data = (
-            self.open_data()[0, :]
-            .map_blocks(M.byteswap, True)
-            .map_blocks(M.newbyteorder, "=")
-            .compute()
-        )
+        data = self.open_data()[0, :].compute()
+        if (sys.byteorder == "little" and data.dtype.byteorder == ">") or (
+            sys.byteorder == "big" and data.dtype.byteorder == "<"
+        ):
+            data = data.byteswap().newbyteorder()
         data = xr.DataArray(
             name=title,
             data=data,

--- a/xgtool3/xgtool3.py
+++ b/xgtool3/xgtool3.py
@@ -75,7 +75,7 @@ class MultiFileGtool3:
         data = [file.open_data() for file in files]
         data = da.concatenate(data)
         time = [file.make_time_ax() for file in files]
-        time = da.concatenate(time)
+        time = np.concatenate(time)
         data = xr.DataArray(
             name=self.datainfo["item"],
             data=data,
@@ -389,6 +389,7 @@ class Gtool3Ax(Gtool3):
             self.open_data()[0, :]
             .map_blocks(M.byteswap, True)
             .map_blocks(M.newbyteorder, "=")
+            .compute()
         )
         data = xr.DataArray(
             name=title,


### PR DESCRIPTION
- MultiFileGtool3を使用する場合、時間軸をdask配列にすると結合時にエラーとなるため、numpy配列に変更した
  - `NotImplementedError: Can not use auto rechunking with object dtype. We are unable to estimate the size in bytes of object data`
- README.mdの更新
- setup.pyのバージョン番号を変更 (2.1.0→2.1.1)