### PR TITLE
Numpy 2.0 で newbyteorder() がエラーになる

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="xgtool3",
-    version="2.1.1",
+    version="2.1.2",
     author="Keiichi Hashimoto",
     author_email="k1bridgebook@g.ecc.u-tokyo.ac.jp",
     packages=find_packages(),

--- a/xgtool3/xgtool3.py
+++ b/xgtool3/xgtool3.py
@@ -424,7 +424,7 @@ class Gtool3Ax(Gtool3):
         if (sys.byteorder == "little" and data.dtype.byteorder == ">") or (
             sys.byteorder == "big" and data.dtype.byteorder == "<"
         ):
-            data = data.byteswap().newbyteorder()
+            data = data.byteswap().view(data.dtype.newbyteorder())
         data = xr.DataArray(
             name=title,
             data=data,


### PR DESCRIPTION
以下のエラーが発生する
```
  File "/home/ytakano/projects/coco_heat_budget/gt_to_nc.py", line 14, in convert_single
    da = xgt3.Gtool3(f"org/{ym}01/gt3/{vname}.gt3").open()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ytakano/miniforge3/envs/weather312/lib/python3.12/site-packages/xgtool3/xgtool3.py", line 138, in __init__
    self.parse_file()
  File "/home/ytakano/miniforge3/envs/weather312/lib/python3.12/site-packages/xgtool3/xgtool3.py", line 177, in parse_file
    self.open_axs()
  File "/home/ytakano/miniforge3/envs/weather312/lib/python3.12/site-packages/xgtool3/xgtool3.py", line 298, in open_axs
    ax = Gtool3Ax(path).open()[self.datainfo["axsel"][i]]
         ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ytakano/miniforge3/envs/weather312/lib/python3.12/site-packages/xgtool3/xgtool3.py", line 427, in open
    data = data.byteswap().newbyteorder()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: `newbyteorder` was removed from the ndarray class in NumPy 2.0. Use `arr.view(arr.dtype.newbyteorder(order))` instead.
```

実行環境
- python                    3.12.4 
- numpy                     2.0.1
- xgtool3                   2.1.1 
